### PR TITLE
Add GitHub Skills activity

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -74,6 +74,12 @@ activities = {
         "schedule": "Fridays, 4:00 PM - 5:30 PM",
         "max_participants": 12,
         "participants": ["charlotte@mergington.edu", "henry@mergington.edu"]
+    },
+    "GitHub Skills": {
+        "description": "Learn practical coding and collaboration skills through GitHub's hands-on exercises and certification program",
+        "schedule": "Wednesdays, 3:30 PM - 4:30 PM",
+        "max_participants": 20,
+        "participants": []
     }
 }
 


### PR DESCRIPTION
Closes #6

## Summary
Adds the GitHub Skills activity to the extracurricular activities list, resolving the missing activity reported by students.

## Changes
- Added `GitHub Skills` entry to the `activities` dictionary in `src/app.py` with a description, schedule (Wednesdays 3:30–4:30 PM), and a max capacity of 20 participants.